### PR TITLE
Fix locale nullability bug

### DIFF
--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
@@ -21,11 +21,11 @@ class LocaleManager(context: Context?) {
         return updateResources(c, language)
     }
 
-    val language: String?
+    val language: String
         get() = prefs.getString(
             LANGUAGE_KEY,
             LANGUAGE_ENGLISH
-        )
+        ) ?: LANGUAGE_ENGLISH
 
     @SuppressLint("ApplySharedPref")
     private fun persistLanguage(language: String) { // use commit() instead of apply(), because sometimes we kill the application process immediately
@@ -35,7 +35,7 @@ class LocaleManager(context: Context?) {
 
     private fun updateResources(
         context: Context,
-        language: String?
+        language: String
     ): Context {
         var context = context
         val locale = Locale(language)


### PR DESCRIPTION
## Summary
- strengthen `LocaleManager` language handling to avoid returning null
- update resource update API to accept non-null string

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687b2ef25de8832badf396cbc26c8d55