### PR TITLE
ใช้ AndroidX PreferenceManager แทนเวอร์ชันเดิม

### DIFF
--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
@@ -7,10 +7,10 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Build
 import android.os.Build.VERSION_CODES
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import java.util.*
 
-class LocaleManager(context: Context?) {
+class LocaleManager(context: Context) {
     private val prefs: SharedPreferences
     fun setLocale(c: Context): Context {
         return updateResources(c, language)


### PR DESCRIPTION
## สรุป
- เปลี่ยน `LocaleManager` ให้ใช้ `androidx.preference.PreferenceManager` และบังคับ `Context` ไม่เป็น null พร้อมสร้าง `prefs` ด้วย API ใหม่นี้
- เพิ่ม dependency `androidx.preference:preference-ktx` ในโมดูล `kotlinlocalemanager`

## การทดสอบ
- `./gradlew :kotlinlocalemanager:test` ไม่สำเร็จเนื่องจากปัญหา proxy 403 ขณะดาวน์โหลด Gradle Wrapper


------
https://chatgpt.com/codex/tasks/task_e_688afae546d0832ba6438a575b823aa1