### PR TITLE
ปรับปรุงการตั้งค่าภาษาและเพิ่มค่าคงที่

### DIFF
--- a/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
+++ b/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
@@ -2,7 +2,8 @@ package com.ninenox.kotlinmultilanguage
 
 import android.os.Bundle
 import com.ninenox.kotlinlocalemanager.AppCompatActivityBase
-import com.ninenox.kotlinlocalemanager.ApplicationLocale.Companion.localeManager
+import com.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_ENGLISH
+import com.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_THAI
 import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivityBase() {
@@ -17,10 +18,10 @@ class MainActivity : AppCompatActivityBase() {
 
     private fun initView() {
         change_language_th_button.setOnClickListener {
-            setNewLocale("TH")
+            setNewLocale(LANGUAGE_THAI)
         }
         change_language_en_button.setOnClickListener {
-            setNewLocale("EN")
+            setNewLocale(LANGUAGE_ENGLISH)
         }
     }
 

--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
@@ -17,8 +17,9 @@ class LocaleManager(context: Context?) {
     }
 
     fun setNewLocale(c: Context, language: String): Context {
-        persistLanguage(language)
-        return updateResources(c, language)
+        val lang = language.lowercase(Locale.ROOT)
+        persistLanguage(lang)
+        return updateResources(c, lang)
     }
 
     val language: String
@@ -55,6 +56,7 @@ class LocaleManager(context: Context?) {
 
     companion object {
         //const val LANGUAGE_FARSI = "fa"
+        const val LANGUAGE_THAI = "th"
         const val LANGUAGE_ENGLISH = "en"
         private const val LANGUAGE_KEY = "language_key"
         fun getLocale(res: Resources): Locale {


### PR DESCRIPTION
## สรุป
- แปลงรหัสภาษาด้วย `Locale.ROOT` ก่อนบันทึกและอัปเดตทรัพยากร
- เพิ่มค่าคงที่ภาษาไทยและใช้งานในหน้าหลัก

## การทดสอบ
- `./gradlew test` *(ล้มเหลว: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688afaef0f78832baa29781466932eaa