### PR TITLE
refactor: safe locale manager initialization

### DIFF
--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/AppCompatActivityBase.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/AppCompatActivityBase.kt
@@ -9,7 +9,8 @@ import androidx.appcompat.app.AppCompatActivity
 abstract class AppCompatActivityBase : AppCompatActivity() {
 
     override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(ApplicationLocale.localeManager!!.setLocale(base))
+        val context = ApplicationLocale.localeManager?.setLocale(base) ?: base
+        super.attachBaseContext(context)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -40,7 +41,7 @@ abstract class AppCompatActivityBase : AppCompatActivity() {
     }
 
     fun setNewLocale(language: String): Boolean {
-        ApplicationLocale.localeManager!!.setNewLocale(this, language)
+        ApplicationLocale.localeManager?.setNewLocale(this, language)
         recreate()
 //        val i = Intent(this, MainActivity::class.java)
 //        startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK))

--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/ApplicationLocale.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/ApplicationLocale.kt
@@ -7,17 +7,25 @@ import android.content.res.Configuration
 open class ApplicationLocale : Application() {
 
     override fun attachBaseContext(base: Context) {
-        localeManager = LocaleManager(base)
-        super.attachBaseContext(localeManager!!.setLocale(base))
+        initializeLocaleManager(base)
+        super.attachBaseContext(localeManager?.setLocale(base) ?: base)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        localeManager!!.setLocale(this)
+        localeManager?.setLocale(this)
     }
 
     companion object {
         // for the sake of simplicity. use DI in real apps instead
-        var localeManager: LocaleManager? = null
+        private var _localeManager: LocaleManager? = null
+        val localeManager: LocaleManager?
+            get() = _localeManager
+
+        fun initializeLocaleManager(context: Context) {
+            if (_localeManager == null) {
+                _localeManager = LocaleManager(context)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ตรวจสอบค่า `localeManager` ก่อนเรียกใช้งาน เพื่อเลี่ยง `!!`
- เพิ่มการสร้าง `localeManager` แบบ lazy เพื่อให้มีค่าเสมอ

## Testing
- `./gradlew build` *(ล้มเหลว: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688afaff45e0832b9311191da4bdc6e0