### PR TITLE
docs: clarify language code access

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ setNewLocale("en-US") // ตัวอย่าง "en-US","th-TH","de-DE"...
 
 ```
 
-6. Get current code language string.
+6. Get current language code string.
+ค่าของ `language` จะเป็นรหัสภาษาตัวพิมพ์เล็ก เช่น "en" หรือ "th" และแนะนำให้เข้าถึงผ่าน `ApplicationLocale.localeManager?.language` เพื่อใช้ตัวจัดการที่แชร์ทั่วทั้งแอป
 ```
-LocaleManager(this).language.toString() // "en-US"
+ApplicationLocale.localeManager?.language // "en"
 ```
         
 


### PR DESCRIPTION
## Summary
- clarify that language codes are lowercase and use shared manager access

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688b031657e4832babee99a5829c00ec