### PR TITLE
docs: document LocaleManager.getLocale usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ setNewLocale("en-US") // ตัวอย่าง "en-US","th-TH","de-DE"...
 ```
 LocaleManager(this).language.toString() // "en-US"
 ```
+
+7. Get current `Locale` instance.
+
+`LocaleManager.getLocale(resources)` will return the current `Locale` and can be used for country checks or locale-aware formatting.
+
+```kotlin
+val locale = LocaleManager.getLocale(resources)
+
+if (locale.country == "TH") {
+    // ประเทศไทย
+}
+
+val dateFormat = java.text.DateFormat.getDateInstance(java.text.DateFormat.SHORT, locale)
+val formattedDate = dateFormat.format(java.util.Date())
+```
         
 
 


### PR DESCRIPTION
## Summary
- document that `LocaleManager.getLocale(resources)` returns the current `Locale`
- add Kotlin example demonstrating country check and date formatting

## Testing
- `gradle test` *(fails: Could not GET required artifacts, received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_688b03189c54832b92118dbca15a3ce8