### PR TITLE
Remove synthetic view usage and enable view binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,14 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 
 
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
+    buildFeatures {
+        viewBinding true
+    }
     defaultConfig {
         applicationId "com.ninenox.kotlinmultilanguage"
         minSdkVersion 15

--- a/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
+++ b/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
@@ -4,27 +4,27 @@ import android.os.Bundle
 import com.ninenox.kotlinlocalemanager.AppCompatActivityBase
 import com.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_ENGLISH
 import com.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_THAI
-import kotlinx.android.synthetic.main.activity_main.*
+import com.ninenox.kotlinmultilanguage.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivityBase() {
 
+    private lateinit var binding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         initView()
-
     }
 
     private fun initView() {
-        change_language_th_button.setOnClickListener {
+        binding.changeLanguageThButton.setOnClickListener {
             setNewLocale("th-TH")
         }
-        change_language_en_button.setOnClickListener {
+        binding.changeLanguageEnButton.setOnClickListener {
             setNewLocale("en-US")
 
         }
     }
-
-
 }

--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 tasks.withType(Javadoc).all {
     enabled = false
@@ -9,7 +8,9 @@ tasks.withType(Javadoc).all {
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
-
+    buildFeatures {
+        viewBinding true
+    }
 
     defaultConfig {
         minSdkVersion 15


### PR DESCRIPTION
## Summary
- enable view binding in app and kotlinlocalemanager modules
- refactor MainActivity to use ActivityMainBinding instead of synthetic views

## Testing
- `./gradlew test` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ca7c49c832ba433062edc6d2267