### PR TITLE
Use locale constants for language selection

### DIFF
--- a/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
+++ b/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
@@ -18,10 +18,10 @@ class MainActivity : AppCompatActivityBase() {
 
     private fun initView() {
         change_language_th_button.setOnClickListener {
-            setNewLocale("th-TH")
+            setNewLocale(LANGUAGE_THAI)
         }
         change_language_en_button.setOnClickListener {
-            setNewLocale("en-US")
+            setNewLocale(LANGUAGE_ENGLISH)
 
         }
     }


### PR DESCRIPTION
## Summary
- replace hardcoded locale strings with language constants

## Testing
- `./gradlew test` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68b25e2bf9f0832bbf60e4acaeafd14e