### PR TITLE
Rename context parameter in updateResources

### DIFF
--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/LocaleManager.kt
@@ -35,10 +35,10 @@ class LocaleManager(context: Context) {
     }
 
     private fun updateResources(
-        context: Context,
+        ctx: Context,
         language: String
     ): Context {
-        var context = context
+        var context = ctx
         val locale = if (Build.VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
             Locale.forLanguageTag(language)
         } else {


### PR DESCRIPTION
## Summary
- rename updateResources parameter from `context` to `ctx`
- adjust internal variable assignment to match new parameter

## Testing
- `./gradlew test` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68b25efa835c832b88d94a83ed087de2