### PR TITLE
refactor: simplify AppCompatActivityBase locale handling

### DIFF
--- a/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/AppCompatActivityBase.kt
+++ b/kotlinlocalemanager/src/main/java/com/ninenox/kotlinlocalemanager/AppCompatActivityBase.kt
@@ -1,7 +1,6 @@
 package com.ninenox.kotlinlocalemanager
 
 import android.content.Context
-import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -15,20 +14,6 @@ abstract class AppCompatActivityBase : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        //resetTitle()
-    }
-
-    private fun resetTitle() {
-        try {
-            val label = packageManager.getActivityInfo(
-                componentName,
-                PackageManager.GET_META_DATA
-            ).labelRes
-            if (label != 0) {
-                setTitle(label)
-            }
-        } catch (e: PackageManager.NameNotFoundException) {
-        }
     }
 
     override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
@@ -43,13 +28,6 @@ abstract class AppCompatActivityBase : AppCompatActivity() {
     fun setNewLocale(language: String): Boolean {
         ApplicationLocale.localeManager?.setNewLocale(this, language)
         recreate()
-//        val i = Intent(this, MainActivity::class.java)
-//        startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK))
-//        if (restartProcess) {
-//            System.exit(0)
-//        } else {
-//            Toast.makeText(this, "Activity restarted", Toast.LENGTH_LONG).show()
-//        }
         return true
     }
 }


### PR DESCRIPTION
## Summary
- remove unused `resetTitle` and associated code
- prune outdated commented code in `setNewLocale`

## Testing
- `./gradlew test` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68b25f757520832b900ef2418f46d06f