### PR TITLE
Add Robolectric tests for LocaleManager

### DIFF
--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/kotlinlocalemanager/src/test/java/com/ninenox/kotlinlocalemanager/LocaleManagerTest.kt
+++ b/kotlinlocalemanager/src/test/java/com/ninenox/kotlinlocalemanager/LocaleManagerTest.kt
@@ -1,0 +1,34 @@
+package com.ninenox.kotlinlocalemanager
+
+import android.os.Build
+import androidx.preference.PreferenceManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class LocaleManagerTest {
+
+    @Test
+    fun setNewLocale_savesLanguageAndUpdatesConfiguration() {
+        val context = RuntimeEnvironment.getApplication()
+        val localeManager = LocaleManager(context)
+
+        val updatedContext = localeManager.setNewLocale(context, LocaleManager.LANGUAGE_THAI)
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        assertEquals(LocaleManager.LANGUAGE_THAI, prefs.getString("language_key", ""))
+
+        val resLocale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            updatedContext.resources.configuration.locales[0]
+        } else {
+            @Suppress("DEPRECATION")
+            updatedContext.resources.configuration.locale
+        }
+        assertEquals(Locale("th"), resLocale)
+        assertEquals(Locale("th"), Locale.getDefault())
+    }
+}


### PR DESCRIPTION
## Summary
- add Robolectric dependency for unit tests
- test LocaleManager.setNewLocale saves language and updates configuration

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b2611f4588832baa8e13ede6b65bda