### PR TITLE
เพิ่มใบอนุญาต MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Nisit Sirimarnkit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/kotlinlocalemanager/bintray.gradle
+++ b/kotlinlocalemanager/bintray.gradle
@@ -37,7 +37,7 @@ bintray {
         desc = 'Android kotlin change Language at runtime.' // YOUR LIBRARY DESCRIPTION
         websiteUrl = 'https://github.com/nisit15/KotlinMultiLanguage' // YOUR SITE
         vcsUrl = 'https://github.com/nisit15/KotlinMultiLanguage.git' // YOUR GIT REPO
-        licenses = ["Apache-2.0"] // A LIST OF YOUR LICENCES
+        licenses = ["MIT"] // A LIST OF YOUR LICENCES
         publish = true
         publicDownloadNumbers = true
     }

--- a/kotlinlocalemanager/install.gradle
+++ b/kotlinlocalemanager/install.gradle
@@ -16,8 +16,8 @@ install {
 
                 licenses {
                     license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name 'The MIT License'
+                        url 'https://opensource.org/licenses/MIT'
                     }
                 }
                 developers {


### PR DESCRIPTION
## Summary
- เพิ่มไฟล์ MIT license ให้โปรเจกต์
- ปรับสคริปต์ bintray และ install.gradle ให้ระบุ MIT license

## Testing
- ⚠️ `./gradlew test` — ไม่สามารถดาวน์โหลด Gradle wrapper ได้ (HTTP 403)

------
https://chatgpt.com/codex/tasks/task_e_68b26543fad8832b86630d321e4f9992