### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-     implementation 'com.ninenox.kotlinlocalemanager:kotlin-locale-manager:1.0.0'
+     implementation 'com.ninenox.kotlinlocalemanager:kotlin-locale-manager:1.0.1'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Maven Central credentials
+ossrhUsername=
+ossrhPassword=

--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -7,7 +7,7 @@ tasks.withType(Javadoc).all {
 }
 
 group = 'com.ninenox.kotlinlocalemanager'
-version = '1.0.0'
+version = '1.0.1'
 
 android {
     compileSdkVersion 34
@@ -20,7 +20,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -66,7 +66,7 @@ afterEvaluate {
                 artifact javadocJar
                 groupId = 'com.ninenox.kotlinlocalemanager'
                 artifactId = 'kotlin-locale-manager'
-                version = '1.0.0'
+                version = '1.0.1'
                 pom {
                     name.set('kotlinlocalemanager')
                     description.set('Android kotlin change Language at runtime.')


### PR DESCRIPTION
## Summary
- ปรับเวอร์ชันไลบรารีเป็น 1.0.1 และอัปเดต `versionName`
- แก้ README ให้ระบุ dependency เวอร์ชัน 1.0.1
- เพิ่มช่อง username/password สำหรับ Maven Central ใน `gradle.properties`

## Testing
- `./gradlew clean build publish` *(ล้มเหลว: ไม่สามารถดาวน์โหลด dependencies จาก Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b30f061840832bb1d2965abcacb89d