### PR TITLE
fix: use archiveClassifier for JAR tasks

### DIFF
--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -50,11 +50,11 @@ dependencies {
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+    archiveClassifier.set('sources')
 }
 
 task javadocJar(type: Jar) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
 }
 
 afterEvaluate {


### PR DESCRIPTION
## Summary
- fix sourcesJar and javadocJar to use archiveClassifier

## Testing
- `./gradlew :kotlinlocalemanager:build` *(fail: Minimum supported Gradle version is 8.6. Current version is 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b0b78dd0832b99f4d0ee9009884b