### PR TITLE
chore: configure Java 21 toolchain

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,18 +4,25 @@ apply plugin: 'kotlin-android'
 
 
 
-android {
-    namespace 'com.ninenox.kotlinmultilanguage'
-    compileSdkVersion 34
-    buildToolsVersion "34.0.0"
-    buildFeatures {
-        viewBinding true
-    }
-    defaultConfig {
-        applicationId "com.ninenox.kotlinmultilanguage"
-        minSdkVersion 21
-        targetSdkVersion 34
-        versionCode 1
+  android {
+      namespace 'com.ninenox.kotlinmultilanguage'
+      compileSdkVersion 34
+      buildToolsVersion "34.0.0"
+      buildFeatures {
+          viewBinding true
+      }
+      compileOptions {
+          sourceCompatibility JavaVersion.VERSION_21
+          targetCompatibility JavaVersion.VERSION_21
+      }
+      kotlinOptions {
+          jvmTarget = "21"
+      }
+      defaultConfig {
+          applicationId "com.ninenox.kotlinmultilanguage"
+          minSdkVersion 21
+          targetSdkVersion 34
+          versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,14 @@ allprojects {
     }
 }
 
+subprojects {
+    plugins.withId('org.jetbrains.kotlin.android') {
+        kotlin {
+            jvmToolchain(21)
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Aug 31 09:14:28 ICT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -9,17 +9,24 @@ tasks.withType(Javadoc).all {
 group = 'com.ninenox.kotlinlocalemanager'
 version = '1.0.1'
 
-android {
-    namespace 'com.ninenox.kotlinlocalemanager'
-    compileSdkVersion 34
-    buildToolsVersion "34.0.0"
-    buildFeatures {
-        viewBinding true
-    }
+  android {
+      namespace 'com.ninenox.kotlinlocalemanager'
+      compileSdkVersion 34
+      buildToolsVersion "34.0.0"
+      buildFeatures {
+          viewBinding true
+      }
+      compileOptions {
+          sourceCompatibility JavaVersion.VERSION_21
+          targetCompatibility JavaVersion.VERSION_21
+      }
+      kotlinOptions {
+          jvmTarget = "21"
+      }
 
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 34
+      defaultConfig {
+          minSdkVersion 21
+          targetSdkVersion 34
         versionCode 1
         versionName "1.0.1"
 


### PR DESCRIPTION
## Summary
- setup Kotlin toolchain to use Java 21
- enforce Java 21 compatibility in app and library modules
- update Gradle wrapper to 8.7

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bafd8b3c832ba2d1b971bf8c4adb