### PR TITLE
chore: centralize JDK 17 configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,13 +11,6 @@ apply plugin: 'kotlin-android'
       buildFeatures {
           viewBinding true
       }
-      compileOptions {
-          sourceCompatibility JavaVersion.VERSION_17
-          targetCompatibility JavaVersion.VERSION_17
-      }
-      kotlinOptions {
-          jvmTarget = "17"
-      }
       defaultConfig {
           applicationId "com.ninenox.kotlinmultilanguage"
           minSdkVersion 21

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,17 @@ subprojects {
             jvmToolchain(17)
         }
     }
+    plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
+        android {
+            compileOptions {
+                sourceCompatibility JavaVersion.VERSION_17
+                targetCompatibility JavaVersion.VERSION_17
+            }
+            kotlinOptions {
+                jvmTarget = "17"
+            }
+        }
+    }
 }
 
 task clean(type: Delete) {

--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -16,13 +16,6 @@ version = '1.0.1'
       buildFeatures {
           viewBinding true
       }
-      compileOptions {
-          sourceCompatibility JavaVersion.VERSION_17
-          targetCompatibility JavaVersion.VERSION_17
-      }
-      kotlinOptions {
-          jvmTarget = "17"
-      }
 
       defaultConfig {
           minSdkVersion 21


### PR DESCRIPTION
## Summary
- enforce Java 17 and Kotlin jvmTarget 17 across subprojects
- simplify module build scripts to rely on centralized configuration

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b3c5dda2dc832b854053cc98d87aea