### PR TITLE
Enable Gradle JDK auto-provisioning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,7 @@ kotlin.code.style=official
 # Maven Central credentials
 ossrhUsername=
 ossrhPassword=
+
+# Enable automatic detection and download of required JDKs
+org.gradle.java.installations.auto-detect=true
+org.gradle.java.installations.auto-download=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
+
 include ':app', ':kotlinlocalemanager'
 rootProject.name='KotlinMultiLanguage'


### PR DESCRIPTION
## Summary
- add Foojay toolchain resolver plugin in settings.gradle
- enable automatic JDK detection and download in gradle.properties

## Testing
- `./gradlew tasks` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ca97dca8832b8d9d5ef41f7276ce