### PR TITLE
chore: configure Kotlin compile for JVM 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,15 +28,17 @@ subprojects {
         kotlin {
             jvmToolchain(17)
         }
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                jvmTarget = "17"
+            }
+        }
     }
     plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
         android {
             compileOptions {
                 sourceCompatibility JavaVersion.VERSION_17
                 targetCompatibility JavaVersion.VERSION_17
-            }
-            kotlinOptions {
-                jvmTarget = "17"
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure Kotlin compiler uses JVM 17
- set Java compile compatibility to 17 for all Android modules

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b3ccfd2838832b93cf0990457bd26a