### PR TITLE
Use AGP to generate sources JAR automatically

### DIFF
--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -9,17 +9,17 @@ tasks.withType(Javadoc).all {
 group = 'com.ninenox.kotlinlocalemanager'
 version = '1.0.1'
 
-  android {
-      namespace 'com.ninenox.kotlinlocalemanager'
-      compileSdkVersion 34
-      buildToolsVersion "34.0.0"
-      buildFeatures {
-          viewBinding true
-      }
+android {
+    namespace 'com.ninenox.kotlinlocalemanager'
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
+    buildFeatures {
+        viewBinding true
+    }
 
-      defaultConfig {
-          minSdkVersion 21
-          targetSdkVersion 34
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0.1"
 
@@ -34,6 +34,11 @@ version = '1.0.1'
         }
     }
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -49,22 +54,11 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set('sources')
-}
-
-task javadocJar(type: Jar) {
-    archiveClassifier.set('javadoc')
-}
-
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
                 from components.release
-                artifact sourcesJar
-                artifact javadocJar
                 groupId = 'com.ninenox.kotlinlocalemanager'
                 artifactId = 'kotlin-locale-manager'
                 version = '1.0.1'


### PR DESCRIPTION
## Summary
- Use Android Gradle Plugin's `withSourcesJar` to build sources JAR automatically.
- Remove custom `sourcesJar` and `javadocJar` tasks.

## Testing
- `./gradlew build` *(fails: Plugin [id: 'org.gradle.toolchains.foojay-resolver-convention', version: '0.4.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d10150cc832b908d8fc0d6493248