### PR TITLE
feat: use io.github.ninenox namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-     implementation 'com.ninenox.kotlinlocalemanager:kotlin-locale-manager:1.0.1'
+     implementation 'io.github.ninenox:kotlin-locale-manager:1.0.1'
 }
 ```
 

--- a/app/src/main/java/com/ninenox/kotlinmultilanguage/App.kt
+++ b/app/src/main/java/com/ninenox/kotlinmultilanguage/App.kt
@@ -3,8 +3,8 @@ package com.ninenox.kotlinmultilanguage
 import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
-import com.ninenox.kotlinlocalemanager.ApplicationLocale
-import com.ninenox.kotlinlocalemanager.LocaleManager
+import io.github.ninenox.kotlinlocalemanager.ApplicationLocale
+import io.github.ninenox.kotlinlocalemanager.LocaleManager
 
 class App : ApplicationLocale() {
 

--- a/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
+++ b/app/src/main/java/com/ninenox/kotlinmultilanguage/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.ninenox.kotlinmultilanguage
 
 import android.os.Bundle
-import com.ninenox.kotlinlocalemanager.AppCompatActivityBase
-import com.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_ENGLISH
-import com.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_THAI
+import io.github.ninenox.kotlinlocalemanager.AppCompatActivityBase
+import io.github.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_ENGLISH
+import io.github.ninenox.kotlinlocalemanager.LocaleManager.Companion.LANGUAGE_THAI
 import com.ninenox.kotlinmultilanguage.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivityBase() {

--- a/kotlinlocalemanager/build.gradle
+++ b/kotlinlocalemanager/build.gradle
@@ -6,11 +6,11 @@ tasks.withType(Javadoc).configureEach {
     enabled = false
 }
 
-group = 'com.ninenox.kotlinlocalemanager'
+group = 'io.github.ninenox'
 version = '1.0.1'
 
 android {
-    namespace 'com.ninenox.kotlinlocalemanager'
+    namespace 'io.github.ninenox.kotlinlocalemanager'
     compileSdkVersion 34
     buildToolsVersion "34.0.0"
     buildFeatures {
@@ -59,7 +59,7 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId = 'com.ninenox.kotlinlocalemanager'
+                groupId = 'io.github.ninenox'
                 artifactId = 'kotlin-locale-manager'
                 version = '1.0.1'
                 pom {

--- a/kotlinlocalemanager/src/androidTest/java/io/github/ninenox/kotlinlocalemanager/ExampleInstrumentedTest.kt
+++ b/kotlinlocalemanager/src/androidTest/java/io/github/ninenox/kotlinlocalemanager/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.ninenox.kotlinlocalemanager
+package io.github.ninenox.kotlinlocalemanager
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.ninenox.kotlinlocalemanager.test", appContext.packageName)
+        assertEquals("io.github.ninenox.kotlinlocalemanager.test", appContext.packageName)
     }
 }

--- a/kotlinlocalemanager/src/main/AndroidManifest.xml
+++ b/kotlinlocalemanager/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ninenox.kotlinlocalemanager" />
+    package="io.github.ninenox.kotlinlocalemanager" />

--- a/kotlinlocalemanager/src/main/java/io/github/ninenox/kotlinlocalemanager/AppCompatActivityBase.kt
+++ b/kotlinlocalemanager/src/main/java/io/github/ninenox/kotlinlocalemanager/AppCompatActivityBase.kt
@@ -1,4 +1,4 @@
-package com.ninenox.kotlinlocalemanager
+package io.github.ninenox.kotlinlocalemanager
 
 import android.content.Context
 import android.content.res.Configuration

--- a/kotlinlocalemanager/src/main/java/io/github/ninenox/kotlinlocalemanager/ApplicationLocale.kt
+++ b/kotlinlocalemanager/src/main/java/io/github/ninenox/kotlinlocalemanager/ApplicationLocale.kt
@@ -1,4 +1,4 @@
-package com.ninenox.kotlinlocalemanager
+package io.github.ninenox.kotlinlocalemanager
 
 import android.app.Application
 import android.content.Context

--- a/kotlinlocalemanager/src/main/java/io/github/ninenox/kotlinlocalemanager/LocaleManager.kt
+++ b/kotlinlocalemanager/src/main/java/io/github/ninenox/kotlinlocalemanager/LocaleManager.kt
@@ -1,4 +1,4 @@
-package com.ninenox.kotlinlocalemanager
+package io.github.ninenox.kotlinlocalemanager
 
 import android.annotation.SuppressLint
 import android.content.Context

--- a/kotlinlocalemanager/src/test/java/io/github/ninenox/kotlinlocalemanager/ExampleUnitTest.kt
+++ b/kotlinlocalemanager/src/test/java/io/github/ninenox/kotlinlocalemanager/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.ninenox.kotlinlocalemanager
+package io.github.ninenox.kotlinlocalemanager
 
 import org.junit.Test
 

--- a/kotlinlocalemanager/src/test/java/io/github/ninenox/kotlinlocalemanager/LocaleManagerTest.kt
+++ b/kotlinlocalemanager/src/test/java/io/github/ninenox/kotlinlocalemanager/LocaleManagerTest.kt
@@ -1,4 +1,4 @@
-package com.ninenox.kotlinlocalemanager
+package io.github.ninenox.kotlinlocalemanager
 
 import android.os.Build
 import androidx.preference.PreferenceManager


### PR DESCRIPTION
## Summary
- use io.github.ninenox for library namespace and group
- update README and sample app imports

## Testing
- `./gradlew test` *(fails: Plugin [id: 'org.gradle.toolchains.foojay-resolver-convention', version: '0.4.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ea7ced9c832b9db7057bb0489c8c