### PR TITLE
Enable checksum generation for Maven publish

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,7 @@ ossrhPassword=
 # Enable automatic detection and download of required JDKs
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=true
+
+# Enable generation of checksum files (MD5/SHA1) when publishing
+systemProp.org.gradle.internal.publish.checksums=true
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,9 +5,7 @@ pluginManagement {
     }
 }
 
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
-}
+
 
 include ':app', ':kotlinlocalemanager'
 rootProject.name='KotlinMultiLanguage'


### PR DESCRIPTION
## Summary
- enable md5/sha1 checksum generation during Maven publication
- remove Foojay toolchain resolver plugin to avoid missing plugin errors

## Testing
- `./gradlew clean publishToMavenLocal` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ec07be80832b80961f6b8742e37f