### PR TITLE
docs: add Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 
 # KotlinLocalization
+
+![Maven Central](https://img.shields.io/maven-central/v/io.github.ninenox/kotlin-locale-manager)
+
 Android kotlin library for change ui language in android application on runtime.
 
 ![Alt Text](https://media.giphy.com/media/VEcDJtSPLjQ6X3NRbs/giphy.gif)


### PR DESCRIPTION
## Summary
- show current Maven Central version in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f4796e40832b984c61082a22c246